### PR TITLE
Replace overridden "echo" command with "log" function

### DIFF
--- a/scripts/build_bsp.sh
+++ b/scripts/build_bsp.sh
@@ -19,22 +19,22 @@ bsp_version=$3
 
     mkdir -p ${topdir}/build/${build}/bsp_sources; cd ${topdir}/build/${build}/bsp_sources
 
-    echo "> BSP sources: checking .."
+    log "> BSP sources: checking .."
     if [ ! -d core-secdev-k3 ]; then
-        echo ">> core-secdev-k3: not found. cloning .."
+        log ">> core-secdev-k3: not found. cloning .."
         git clone \
             https://git.ti.com/git/security-development-tools/core-secdev-k3.git \
             --single-branch \
             --depth=1 &>>"${LOG_FILE}"
-        echo ">> core-secdev-k3: cloned"
+        log ">> core-secdev-k3: cloned"
     else
-        echo ">> core-secdev-k3: available"
+        log ">> core-secdev-k3: available"
     fi
     TI_SECURE_DEV_PKG=${topdir}/build/${build}/bsp_sources/core-secdev-k3
 
     if [ ! -d trusted-firmware-a ]; then
         cd ${topdir}/build/${build}/bsp_sources
-        echo ">> atf: not found. cloning .."
+        log ">> atf: not found. cloning .."
         atf_srcrev=($(read_bsp_config ${bsp_version} atf_srcrev))
 
         git clone https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git &>>"${LOG_FILE}"
@@ -42,15 +42,15 @@ bsp_version=$3
         cd trusted-firmware-a
         git checkout ${atf_srcrev} &>>"${LOG_FILE}"
         cd ..
-        echo ">> atf: cloned"
+        log ">> atf: cloned"
     else
-        echo ">> core-secdev-k3: available"
+        log ">> core-secdev-k3: available"
     fi
     TFA_DIR=${topdir}/build/${build}/bsp_sources/trusted-firmware-a
 
     if [ ! -d optee_os ]; then
         cd ${topdir}/build/${build}/bsp_sources
-        echo ">> optee_os: not found. cloning .."
+        log ">> optee_os: not found. cloning .."
         optee_srcrev=($(read_bsp_config ${bsp_version} optee_srcrev))
 
         git clone https://github.com/OP-TEE/optee_os.git &>>"${LOG_FILE}"
@@ -58,60 +58,60 @@ bsp_version=$3
         cd optee_os
         git checkout ${optee_srcrev} &>>"${LOG_FILE}"
         cd ..
-        echo ">> optee_os: cloned"
+        log ">> optee_os: cloned"
     else
-        echo ">> optee_os: available"
+        log ">> optee_os: available"
     fi
     OPTEE_DIR=${topdir}/build/${build}/bsp_sources/optee_os
 
     if [ ! -d ti-u-boot ]; then
         cd ${topdir}/build/${build}/bsp_sources
-        echo ">> ti-u-boot: not found. cloning .."
+        log ">> ti-u-boot: not found. cloning .."
         uboot_srcrev=($(read_bsp_config ${bsp_version} uboot_srcrev))
         git clone \
             https://git.ti.com/git/ti-u-boot/ti-u-boot.git \
             -b ${uboot_srcrev} \
             --single-branch \
             --depth=1 &>>"${LOG_FILE}"
-        echo ">> ti-u-boot: cloned"
+        log ">> ti-u-boot: cloned"
         if [ -d ${topdir}/patches/ti-u-boot ]; then
-            echo ">> ti-u-boot: patching .."
+            log ">> ti-u-boot: patching .."
             cd ti-u-boot
             git apply ${topdir}/patches/ti-u-boot/* &>>"${LOG_FILE}"
             cd ..
         fi
     else
-        echo ">> ti-u-boot: available"
+        log ">> ti-u-boot: available"
     fi
     UBOOT_DIR=${topdir}/build/${build}/bsp_sources/ti-u-boot
 
     if [ ! -d k3-image-gen ]; then
         cd ${topdir}/build/${build}/bsp_sources
-        echo ">> k3-image-gen: not found. cloning .."
+        log ">> k3-image-gen: not found. cloning .."
         k3ig_srcrev=($(read_bsp_config ${bsp_version} k3ig_srcrev))
         git clone \
             https://git.ti.com/git/k3-image-gen/k3-image-gen.git \
             -b ${k3ig_srcrev} \
             --single-branch \
             --depth=1 &>>"${LOG_FILE}"
-        echo ">> k3-image-gen: cloned"
+        log ">> k3-image-gen: cloned"
     else
-        echo ">> k3-image-gen: available"
+        log ">> k3-image-gen: available"
     fi
     K3IG_DIR=${topdir}/build/${build}/bsp_sources/k3-image-gen
 
     if [ ! -d ti-linux-firmware ]; then
         cd ${topdir}/build/${build}/bsp_sources
-        echo ">> ti-linux-firmware: not found. cloning .."
+        log ">> ti-linux-firmware: not found. cloning .."
         linux_fw_srcrev=($(read_bsp_config ${bsp_version} linux_fw_srcrev))
         git clone \
             https://git.ti.com/git/processor-firmware/ti-linux-firmware.git \
             -b ${linux_fw_srcrev} \
             --single-branch \
             --depth=1 &>>"${LOG_FILE}"
-        echo ">> ti-linux-firmware: cloned"
+        log ">> ti-linux-firmware: cloned"
     else
-        echo ">> ti-linux-firmware: available"
+        log ">> ti-linux-firmware: available"
     fi
     dmfw_machine=($(read_machine_config ${machine} dmfw_machine))
     SYSFW_DIR=${topdir}/build/${build}/bsp_sources/ti-linux-firmware/ti-sysfw
@@ -119,51 +119,51 @@ bsp_version=$3
 
     if [ ! -d ti-linux-kernel ]; then
         cd ${topdir}/build/${build}/bsp_sources
-        echo ">> ti-linux-kernel: not found. cloning .."
+        log ">> ti-linux-kernel: not found. cloning .."
         linux_kernel_srcrev=($(read_bsp_config ${bsp_version} linux_kernel_srcrev))
         git clone \
             https://git.ti.com/git/ti-linux-kernel/ti-linux-kernel.git \
             -b ${linux_kernel_srcrev} \
             --single-branch \
             --depth=1 &>>"${LOG_FILE}"
-        echo ">> ti-linux-kernel: cloned"
+        log ">> ti-linux-kernel: cloned"
         if [ -d ${topdir}/patches/ti-linux-kernel ]; then
-            echo ">> ti-linux-kernel: patching .."
+            log ">> ti-linux-kernel: patching .."
             cd ti-linux-kernel
             git apply ${topdir}/patches/ti-linux-kernel/*
             cd ..
         fi
     else
-        echo ">> ti-linux-kernel: available"
+        log ">> ti-linux-kernel: available"
     fi
     KERNEL_DIR=${topdir}/build/${build}/bsp_sources/ti-linux-kernel
 
     if [ ! -d ti-img-rogue-driver ]; then
         cd ${topdir}/build/${build}/bsp_sources
-        echo ">> ti-img-rogue-driver: not found. cloning .."
+        log ">> ti-img-rogue-driver: not found. cloning .."
         img_rogue_driver_srcrev=($(read_bsp_config ${bsp_version} img_rogue_driver_srcrev))
         git clone \
             https://git.ti.com/git/graphics/ti-img-rogue-driver.git \
             -b ${img_rogue_driver_srcrev} \
             --single-branch \
             --depth=1 &>>"${LOG_FILE}"
-        echo ">> ti-img-rogue-driver: cloned"
+        log ">> ti-img-rogue-driver: cloned"
         if [ -d ${topdir}/patches/ti-img-rogue-driver ]; then
-            echo ">> ti-img-rogue-driver: patching .."
+            log ">> ti-img-rogue-driver: patching .."
             cd ti-img-rogue-driver
             git apply ${topdir}/patches/ti-img-rogue-driver/* &>>"${LOG_FILE}"
             cd ..
         fi
     else
-        echo ">> ti-img-rogue-driver: available"
+        log ">> ti-img-rogue-driver: available"
     fi
     IMG_ROGUE_DRIVER_DIR=${topdir}/build/${build}/bsp_sources/ti-img-rogue-driver
 
-    echo "> BSP sources: cloned"
-    echo "> BSP sources: creating backup .."
+    log "> BSP sources: cloned"
+    log "> BSP sources: creating backup .."
     cd ${topdir}/build/${build}
     tar --use-compress-program="pigz --best --recursive | pv" -cf bsp_sources.tar.xz bsp_sources &>>"${LOG_FILE}"
-    echo "> BSP sources: backup created .."
+    log "> BSP sources: backup created .."
 
     mkdir -p tisdk-${distro}-${machine}-boot
 }
@@ -174,10 +174,10 @@ machine=$1
     cd $TFA_DIR
     target_board=($(read_machine_config ${machine} atf_target_board))
 
-    echo "> ATF: building .."
+    log "> ATF: building .."
     make -j`nproc` ARCH=aarch64 CROSS_COMPILE=aarch64-none-linux-gnu- PLAT=k3 TARGET_BOARD=${target_board} SPD=opteed &>>"${LOG_FILE}"
 
-    echo "> ATF: signing .."
+    log "> ATF: signing .."
     ${TI_SECURE_DEV_PKG}/scripts/secure-binary-image.sh ${TFA_DIR}/build/k3/${target_board}/release/bl31.bin ${TFA_DIR}/build/k3/${target_board}/release/bl31.bin.signed &>>"${LOG_FILE}"
 }
 
@@ -187,10 +187,10 @@ machine=$1
     cd ${OPTEE_DIR}
     platform=($(read_machine_config ${machine} optee_platform))
 
-    echo "> optee: building .."
+    log "> optee: building .."
     make -j`nproc` CROSS_COMPILE64=aarch64-none-linux-gnu- CROSS_COMPILE=arm-none-linux-gnueabihf- PLATFORM=${platform} CFG_ARM64_core=y &>>"${LOG_FILE}"
 
-    echo "> optee: signing .."
+    log "> optee: signing .."
     ${TI_SECURE_DEV_PKG}/scripts/secure-binary-image.sh ${OPTEE_DIR}/out/arm-plat-k3/core/tee-pager_v2.bin ${OPTEE_DIR}/out/arm-plat-k3/core/tee-pager_v2.bin.signed &>>"${LOG_FILE}"
 }
 
@@ -201,11 +201,11 @@ machine=$1
     uboot_a53_defconfig=($(read_machine_config ${machine} uboot_a53_defconfig))
     sysfw_soc=($(read_machine_config ${machine} sysfw_soc))
 
-    echo "> dmfw: signing .."
+    log "> dmfw: signing .."
     ${TI_SECURE_DEV_PKG}/scripts/secure-binary-image.sh ${DMFW_DIR}/ipc_echo_testb_mcu1_0_release_strip.xer5f ${DMFW_DIR}/ipc_echo_testb_mcu1_0_release_strip.xer5f.signed &>>"${LOG_FILE}"
 
     cd ${UBOOT_DIR}
-    echo "> uboot-r5: building .."
+    log "> uboot-r5: building .."
     TI_SECURE_DEV_PKG=${TI_SECURE_DEV_PKG} make -j`nproc` ARCH=arm CROSS_COMPILE=arm-none-linux-gnueabihf- ${uboot_r5_defconfig} O=${UBOOT_DIR}/out/r5 &>>"${LOG_FILE}"
     TI_SECURE_DEV_PKG=${TI_SECURE_DEV_PKG} make -j`nproc` ARCH=arm CROSS_COMPILE=arm-none-linux-gnueabihf- O=${UBOOT_DIR}/out/r5 &>>"${LOG_FILE}"
 
@@ -217,7 +217,7 @@ machine=$1
     # make -j`nproc` ARCH=arm CROSS_COMPILE=arm-none-linux-gnueabihf- SOC=${sysfw_soc} SOC_TYPE=hs SBL=${UBOOT_DIR}/out/r5/spl/u-boot-spl.bin SYSFW_DIR=${SYSFW_DIR}
 
     cd ${UBOOT_DIR}
-    echo "> uboot-a53: building .."
+    log "> uboot-a53: building .."
     TI_SECURE_DEV_PKG=${TI_SECURE_DEV_PKG} make -j`nproc` ARCH=arm CROSS_COMPILE=aarch64-none-linux-gnu- ${uboot_a53_defconfig} O=${UBOOT_DIR}/out/a53 &>>"${LOG_FILE}"
     TI_SECURE_DEV_PKG=${TI_SECURE_DEV_PKG} make -j`nproc` ARCH=arm CROSS_COMPILE=aarch64-none-linux-gnu- ATF=${TFA_DIR}/build/k3/lite/release/bl31.bin.signed TEE=${OPTEE_DIR}/out/arm-plat-k3/core/tee-pager_v2.bin.signed DM=${DMFW_DIR}/ipc_echo_testb_mcu1_0_release_strip.xer5f.signed O=${UBOOT_DIR}/out/a53 &>>"${LOG_FILE}"
     cp ${UBOOT_DIR}/out/a53/tispl.bin ${topdir}/build/${build}/tisdk-${distro}-${machine}-boot/
@@ -230,26 +230,26 @@ rootfs_dir=$2
 
     cd ${KERNEL_DIR}
 
-    echo "kernel: generating defconfig .."
+    log "kernel: generating defconfig .."
     make -j`nproc` ARCH=arm64 CROSS_COMPILE=aarch64-none-linux-gnu- defconfig ti_arm64_prune.config &>>"${LOG_FILE}"
 
-    echo "kernel: building Image .."
+    log "kernel: building Image .."
     make -j`nproc` ARCH=arm64 CROSS_COMPILE=aarch64-none-linux-gnu- Image &>>"${LOG_FILE}"
 
-    echo "kernel: building DTBs .."
+    log "kernel: building DTBs .."
     make -j`nproc` ARCH=arm64 CROSS_COMPILE=aarch64-none-linux-gnu- dtbs &>>"${LOG_FILE}"
 
-    echo "kernel: building modules .."
+    log "kernel: building modules .."
     make -j`nproc` ARCH=arm64 CROSS_COMPILE=aarch64-none-linux-gnu- modules &>>"${LOG_FILE}"
 
-    echo "kernel: installing Image .."
+    log "kernel: installing Image .."
     cp arch/arm64/boot/Image ${rootfs_dir}/boot/
 
-    echo "kernel: installing DTBs .."
+    log "kernel: installing DTBs .."
     mkdir -p ${rootfs_dir}/boot/dtb
     cp -rf arch/arm64/boot/dts/ti ${rootfs_dir}/boot/dtb/
 
-    echo "kernel: installing modules .."
+    log "kernel: installing modules .."
     make ARCH=arm64  INSTALL_MOD_PATH=${rootfs_dir} modules_install &>>"${LOG_FILE}"
 }
 
@@ -262,10 +262,10 @@ kernel_dir=$3
     pvr_window_system=($(read_machine_config ${machine} pvr_window_system))
     cd ${IMG_ROGUE_DRIVER_DIR}
 
-    echo "ti-img-rogue-driver: building .."
+    log "ti-img-rogue-driver: building .."
     make CROSS_COMPILE=aarch64-none-linux-gnu- ARCH=arm64 KERNELDIR=${kernel_dir} RGX_BVNC="33.15.11.3" BUILD=release PVR_BUILD_DIR=${pvr_target} WINDOW_SYSTEM=${pvr_window_system} &>>"${LOG_FILE}"
 
-    echo "ti-img-rogue-driver: installing .."
+    log "ti-img-rogue-driver: installing .."
     cd binary_am62_linux_wayland_release/target_aarch64/kbuild
     make -C ${kernel_dir} ARCH=arm64 CROSS_COMPILE=aarch64-none-linux-gnu- INSTALL_MOD_PATH=${rootfs_dir} INSTALL_MOD_STRIP=1 M=`pwd` modules_install &>>"${LOG_FILE}"
 }

--- a/scripts/build_distro.sh
+++ b/scripts/build_distro.sh
@@ -24,7 +24,7 @@ build=$1
     
     cd ${topdir}/build/${build}
 
-    echo "> Cleaning up ${build}"
+    log "> Cleaning up ${build}"
     (tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-${distro}-${machine}-rootfs.tar.xz tisdk-${distro}-${machine}-rootfs) &>>"${LOG_FILE}"
 
     rm -rf tisdk-${distro}-${machine}-rootfs
@@ -36,7 +36,7 @@ build=$1
 
     cd ${topdir}/build/
 
-    echo "> Packaging ${build}"
+    log "> Packaging ${build}"
     tar --use-compress-program="pigz --best --recursive | pv" -cf ${build}.tar.xz ${build} &>>"${LOG_FILE}"
 }
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -38,11 +38,7 @@ config=$2
     read_config ${topdir}/builds.toml $build $config
 }
 
-# There are many echo statements in the scripts. To save the scripts from being
-# cluttered by twice the number of "echo" statements, override the "echo"
-# command to call the original "echo" twice behind-the-scenes.
-echo() {
+function log() {
     command echo "$@"
     command echo "$@" >> "$LOG_FILE"
-    #run_cmd command echo "$@"
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,41 +20,41 @@ function setup_log_file() {
 }
 
 function setup_build_tools() {
-    echo "> Arm Toolchain: checking .."
+    log "> Arm Toolchain: checking .."
     if [ ! -d "${topdir}/tools/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf/bin" ]; then
         mkdir -p ${topdir}/tools/
         cd ${topdir}/tools/
 
-        echo "> Arm Toolchain: not found. Downloading .." 
+        log "> Arm Toolchain: not found. Downloading .." 
         wget https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz &>>/dev/null
         if [ $? -eq 0 ]; then
-            echo "> Arm Toolchain: downloaded .."
+            log "> Arm Toolchain: downloaded .."
             tar -Jxf gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz &>>"${LOG_FILE}"
             rm gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz
         else
-            echo "> Arm Toolchain: Failed to download. Exit code: $?"
+            log "> Arm Toolchain: Failed to download. Exit code: $?"
         fi
     else
-        echo "> Arm Toolchain: available"
+        log "> Arm Toolchain: available"
     fi
     export PATH=${topdir}/tools/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf/bin:$PATH
 
-    echo "> Aarch64 Toolchain: checking .."
+    log "> Aarch64 Toolchain: checking .."
     if [ ! -d "${topdir}/tools/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu/bin" ]; then
         mkdir -p ${topdir}/tools/
         cd ${topdir}/tools/
 
-        echo "> Aarch64 Toolchain: not found. downloading .." 
+        log "> Aarch64 Toolchain: not found. downloading .." 
         wget https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz &>>/dev/null
         if [ $? -eq 0 ]; then
-            echo "> Aarch64 Toolchain: downloaded .." 
+            log "> Aarch64 Toolchain: downloaded .." 
             tar -Jxf gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz  &>>"${LOG_FILE}"
             rm gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz
         else
-            echo "> Aarch Toolchain: Failed to download. Exit code: $?"
+            log "> Aarch Toolchain: Failed to download. Exit code: $?"
         fi
     else
-        echo "> Aarch64 Toolchain: available"
+        log "> Aarch64 Toolchain: available"
     fi
     export PATH=${topdir}/tools/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu/bin:$PATH
 }


### PR DESCRIPTION
Github Actions workflow builds the scripts in pieces. It calls the overridden echo command at the end of scripts/common.sh, before the function to set up ${LOG_FILE} is called from setup.sh. As a result, the build fails.

Replace the overridden "echo" command with a function "log", to prevent attempt to access the ${LOG_FILE} before it is made.