### PR TITLE
Migrate to using Binman

### DIFF
--- a/builds.toml
+++ b/builds.toml
@@ -1,17 +1,17 @@
 # This file describes the builds
 
 builds = [
-    "am62x_bookworm_09.00.00.001",
-    "am62x_bullseye_09.00.00.001",
+    "am62x_bookworm_09.00.00.002",
+    "am62x_bullseye_09.00.00.002",
 ]
 
-[am62x_bookworm_09.00.00.001]
+[am62x_bookworm_09.00.00.002]
     machine = "am62xx-evm"
-    bsp_version = "09.00.00.001"
+    bsp_version = "09.00.00.002"
     distro_variant = "bookworm-default"
 
-[am62x_bullseye_09.00.00.001]
+[am62x_bullseye_09.00.00.002]
     machine = "am62xx-evm"
-    bsp_version = "09.00.00.001"
+    bsp_version = "09.00.00.002"
     distro_variant = "bullseye-default"
 

--- a/configs/bsp_sources.toml
+++ b/configs/bsp_sources.toml
@@ -1,12 +1,12 @@
-[09.00.00.001]
+[09.00.00.002]
     kernel_major_version = 6
     uboot_method = "k3ig"
     atf_srcrev = "2fcd408bb3a6756767a43c073c597cef06e7f2d5"
     optee_srcrev = "8e74d47616a20eaa23ca692f4bbbf917a236ed94"
-    uboot_srcrev = "09.00.00.001"
-    k3ig_srcrev = "09.00.00.001"
-    linux_fw_srcrev = "09.00.00.001"
-    linux_kernel_srcrev = "09.00.00.001"
+    uboot_srcrev = "09.00.00.002"
+    k3ig_srcrev = "09.00.00.002"
+    linux_fw_srcrev = "09.00.00.002"
+    linux_kernel_srcrev = "09.00.00.002"
     img_rogue_driver_srcrev = "linuxws/kirkstone/k6.1/23.1.6404501"
 
 [08.06.00.007]


### PR DESCRIPTION
U-Boot internally supports Binman. Using Binman also relieves the scripts of the need to clone and build k3-image-gen and core-secdev-k3. Thus migrate to Binman and thereby also replace k3-image-gen and core-secdev-k3.